### PR TITLE
Use 'default_value' instead of 'default'.

### DIFF
--- a/monoprice_mini.def.json
+++ b/monoprice_mini.def.json
@@ -13,29 +13,29 @@
 
     "overrides": {
         "machine_name": { "default_value": "Monoprice Select Mini" },
-        "machine_heated_bed": { "default": true },
-        "machine_width": { "default": 120 },
-        "machine_height": { "default": 120 },
-        "machine_depth": { "default": 120 },
-        "machine_center_is_zero": { "default": false },
-        "machine_nozzle_size": { "default": 0.4 },
-        "material_diameter": { "default": 1.75 },
-        "machine_nozzle_heat_up_speed": { "default": 2.0 },
-        "machine_nozzle_cool_down_speed": { "default": 2.0 },
-        "machine_head_shape_min_x": { "default": 0 },
-        "machine_head_shape_min_y": { "default": 0 },
-        "machine_head_shape_max_x": { "default": 0 },
-        "machine_head_shape_max_y": { "default": 0 },
-        "machine_nozzle_gantry_distance": { "default": 55 },
-        "machine_disallowed_areas": { "default": []},
-        "machine_gcode_flavor": { "default": "RepRap)" },
-        "machine_platform_offset": { "default": [0.0, 0.0, 0.0] },
+        "machine_heated_bed": { "default_value": true },
+        "machine_width": { "default_value": 120 },
+        "machine_height": { "default_value": 120 },
+        "machine_depth": { "default_value": 120 },
+        "machine_center_is_zero": { "default_value": false },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_nozzle_heat_up_speed": { "default_value": 2.0 },
+        "machine_nozzle_cool_down_speed": { "default_value": 2.0 },
+        "machine_head_shape_min_x": { "default_value": 0 },
+        "machine_head_shape_min_y": { "default_value": 0 },
+        "machine_head_shape_max_x": { "default_value": 0 },
+        "machine_head_shape_max_y": { "default_value": 0 },
+        "machine_nozzle_gantry_distance": { "default_value": 55 },
+        "machine_disallowed_areas": { "default_value": []},
+        "machine_gcode_flavor": { "default_value": "RepRap)" },
+        "machine_platform_offset": { "default_value": [0.0, 0.0, 0.0] },
 
         "machine_start_gcode": {
-            "default": "G21 ;metric values\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG28 X0 Y0 ;move X/Y to min endstops\nG28 Z0 ;move Z to min endstops\nG1 Z15.0 F9000 ;move the platform down 15mm\nG92 E0 ;zero the extruded length\nG1 F200 E3 ;extrude 3mm of feed stock\nG92 E0 ;zero the extruded length again\nG1 F9000\n;Put printing message on LCD screen\nM117 Printing..."
+            "default_value": "G21 ;metric values\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG28 X0 Y0 ;move X/Y to min endstops\nG28 Z0 ;move Z to min endstops\nG1 Z15.0 F9000 ;move the platform down 15mm\nG92 E0 ;zero the extruded length\nG1 F200 E3 ;extrude 3mm of feed stock\nG92 E0 ;zero the extruded length again\nG1 F9000\n;Put printing message on LCD screen\nM117 Printing..."
         },
         "machine_end_gcode": {
-            "default": "M104 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300  ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F9000 ;move Z up a bit and retract filament even more\nG28 X0 Y0 ;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nG90 ;absolute positioning"
+            "default_value": "M104 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300  ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F9000 ;move Z up a bit and retract filament even more\nG28 X0 Y0 ;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nG90 ;absolute positioning"
         }
     }
 }

--- a/monoprice_mini.def.json
+++ b/monoprice_mini.def.json
@@ -26,7 +26,7 @@
         "machine_head_shape_min_y": { "default_value": 0 },
         "machine_head_shape_max_x": { "default_value": 0 },
         "machine_head_shape_max_y": { "default_value": 0 },
-        "machine_nozzle_gantry_distance": { "default_value": 55 },
+        "gantry_height": { "default_value": 55 },
         "machine_disallowed_areas": { "default_value": []},
         "machine_gcode_flavor": { "default_value": "RepRap)" },
         "machine_platform_offset": { "default_value": [0.0, 0.0, 0.0] },


### PR DESCRIPTION
None of the "default" were showing up in Cura 2.6.2, using "default_value" fixes this.